### PR TITLE
add enhanced ssl configuration.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -100,6 +100,14 @@ server {
 	include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
 	ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
+	ssl_ciphers AES:!kDHr:!kDHd:!DSS:!SRP:!kRSA:!kECDHe:!kECDHr:!aNULL:!aECDSA:!aPSK; # PFS(DH/ECDHE), AES(CBC/GCM)
+	ssl_prefer_server_ciphers on;
+	ssl_protocols TLSv1.2;
+	ssl_session_cache builtin:500 shared:SSL:1m;
+	ssl_stapling on; # OCSP Stapling
+
+	add_header Strict-Transport-Security 'max-age=31536000;';
+
 	client_max_body_size 100m;
 	proxy_http_version 1.1;
 


### PR DESCRIPTION
※コミットログのはtypo...

* 暗号スイートをPFSサポートのみ、AES(CBC/GCM)のみに限定
* サーバー側提示の暗号スイートを常に優先
* TLS1.2に限定
* SSLセッションキャッシュの有効化(値は適当……)
* OCSP Staplingを有効化
* HSTSヘッダーの付与

これらを追加したときの `nginx.service` 起動確認は手元のvagrant環境でしていますが、実環境でどうかは不明なので確認お願いします。