### PR TITLE
ruby 4.0.0資材対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   massr:
-    image: wasamas/massr:wasamas
+    image: wasamas/massr:wasamas_v2
     container_name: "massr"
     environment:
       - TZ=Asia/Tokyo
@@ -14,8 +14,10 @@ services:
       - mongodb
       - memcached
   mongodb:
-    image: mongo:3.0
+    image: mongo:4.4
     container_name: "mongodb"
+    security_opt:
+      - seccomp:unconfined
     environment:
       - MONGO_DATA_DIR=/data/db
       - MONGO_LOG_DIR=/data/db/log
@@ -23,7 +25,7 @@ services:
       - ./data/db:/data/db
     ports:
       - 27017:27017
-    command: mongod --smallfiles --logpath=/data/db/log/mongodb.log # --quiet
+    command: mongod --logpath=/data/db/log/mongodb.log # --quiet
   memcached:
     image: memcached:latest
     container_name: "memcached"


### PR DESCRIPTION
- ruby 4.0.0対応版のmassrで作成したdockerイメージを指定するように変更
- mongodbを 3.0から4.4に変更。伴って起動引数を調整